### PR TITLE
DO NOT MERGE: Reproduce NamedModules error

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,8 +1,7 @@
+const { NamedModulesPlugin } = require('webpack');
 const HTMLPlugin = require('html-webpack-plugin');
 const ExtractText = require('extract-text-webpack-plugin');
 const path = require('path');
-
-const extractText = new ExtractText({ filename: 'style.css', ignoreOrder: true });
 
 module.exports = {
   entry: './index.js',
@@ -22,7 +21,7 @@ module.exports = {
     new HTMLPlugin({
       template: path.resolve(__dirname, 'src', 'index.html')
     }),
-    extractText
+    new NamedModulesPlugin()
   ],
   module: {
     rules: [
@@ -32,8 +31,7 @@ module.exports = {
       },
       {
         test: /\.cssm$/,
-        issuer: /\.jsx?$/,
-        use: extractText.loader()
+        use: 'style-loader'
       }
     ]
   }


### PR DESCRIPTION
cssm files do not work with the style-loader when using the
`NamedModulesPlugin`